### PR TITLE
Decrease size of structure InlinableString

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,6 +536,12 @@ mod tests {
     use super::{InlinableString, StringExt, INLINE_STRING_CAPACITY};
     use std::iter::FromIterator;
 
+    #[test]
+    fn test_size() {
+        use std::mem::size_of;
+        assert_eq!(size_of::<InlinableString>(), 4 * size_of::<usize>());
+    }
+
     // First, specifically test operations that overflow InlineString's capacity
     // and require promoting the string to heap allocation.
 


### PR DESCRIPTION
This PR decrease size of `InlinableString` structure:
- from 48 to 32 bytes for 64 arch
- from 40 to 16 bytes for 32 arch.

There are two optimization:
1. Using `u8` instead of `usize` for storing inline length
2. Change inline capacity from 32 bytes to 30 bytes for 64 arch and to 14 bytes for 32 arch to fit exactly into `String` size + 1 byte (discriminant) + alignment.

See detailed explanation into my [Reddit comment](https://www.reddit.com/r/rust/comments/3v2uzv/inlinable_string_a_dropin_replacement_for/cxk0p6b).
