### PR TITLE
impl From<String> for InlinableString

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "inlinable_string"
 
 description = "The `inlinable_string` crate provides the `InlinableString` type -- an owned, grow-able UTF-8 string that stores small strings inline and avoids heap-allocation -- and the `StringExt` trait which abstracts string operations over both `std::string::String` and `InlinableString` (or even your own custom string type)."
 
-version = "0.1.4"
+version = "0.1.5"
 license = "Apache-2.0/MIT"
 keywords = ["string", "inline", "inlinable"]
 readme = "./README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl<'a> From<&'a str> for InlinableString {
     #[inline]
     fn from(string: &'a str) -> InlinableString {
         if string.len() <= INLINE_STRING_CAPACITY {
-            InlinableString::Inline(InlineString::from(string))
+            InlinableString::Inline(string.into())
         } else {
             InlinableString::Heap(string.into())
         }
@@ -217,7 +217,11 @@ impl<'a> From<&'a str> for InlinableString {
 impl From<String> for InlinableString {
     #[inline]
     fn from(string: String) -> InlinableString {
-        InlinableString::Heap(string)
+        if string.len() <= INLINE_STRING_CAPACITY {
+            InlinableString::Inline(string.as_str().into())
+        } else {
+            InlinableString::Heap(string)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,20 +197,27 @@ impl AsRef<str> for InlinableString {
 impl AsMut<str> for InlinableString {
     fn as_mut(&mut self) -> &mut str {
         match *self {
-            InlinableString::Heap(ref mut s) => &mut s[..],
+            InlinableString::Heap(ref mut s) => s.as_mut_str(),
             InlinableString::Inline(ref mut s) => &mut s[..],
         }
     }
 }
 
 impl<'a> From<&'a str> for InlinableString {
+    #[inline]
     fn from(string: &'a str) -> InlinableString {
-        let string_len = string.len();
-        if string_len <= INLINE_STRING_CAPACITY {
+        if string.len() <= INLINE_STRING_CAPACITY {
             InlinableString::Inline(InlineString::from(string))
         } else {
-            InlinableString::Heap(String::from(string))
+            InlinableString::Heap(string.into())
         }
+    }
+}
+
+impl From<String> for InlinableString {
+    #[inline]
+    fn from(string: String) -> InlinableString {
+        InlinableString::Heap(string)
     }
 }
 


### PR DESCRIPTION
In a situation where a `String` is already allocated, having a shortcut to create a `InlinableString::Heap` might be helpful.

Additionally, this enables static generic implementations for `S: Into<InlinableString>` accepting either `&str` or `String`.