### PR TITLE
Add serde to InlinableString

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ before_script:
 
 script:
 - |
-  travis-cargo build &&
-  travis-cargo test &&
+  travis-cargo test -- --features serde &&
   travis-cargo bench &&
   travis-cargo --only stable doc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,12 @@ repository = "https://github.com/fitzgen/inlinable_string"
 optional = true
 version = "0.0.27"
 
+[dependencies.serde]
+optional = true
+version = "1"
+
 [features]
 nightly = ["clippy"]
+
+[dev-dependencies]
+serde_test = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,13 @@
 //! consider using the more restrictive
 //! [`InlineString`](./inline_string/struct.InlineString.html) type. If `member` is
 //! not always small, then it should probably be left as a `String`.
+//! 
+//! # Serialization
+//! 
+//! `InlinableString` implements [`serde`][serde-docs]'s `Serialize` and `Deserialize` traits.
+//! Add the `serde` feature to your `Cargo.toml` to enable serialization.
+//! 
+//! [serde-docs]: https://serde.rs
 
 #![forbid(missing_docs)]
 
@@ -74,9 +81,18 @@
 
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
+#[cfg(all(test, feature = "serde"))]
+extern crate serde_test;
+
 #[cfg(test)]
 #[cfg(feature = "nightly")]
 extern crate test;
+
+#[cfg(feature = "serde")]
+mod serde_impl;
 
 pub mod inline_string;
 pub mod string_ext;

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,0 +1,49 @@
+use std::fmt;
+use serde::{Serialize, Serializer};
+use serde::de::{Deserialize, Deserializer, Visitor, Error as DeError};
+use InlinableString;
+
+impl Serialize for InlinableString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> 
+        where S: Serializer
+    {
+        serializer.serialize_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for InlinableString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>
+    {
+        struct InlinableStringVisitor;
+
+        impl<'de> Visitor<'de> for InlinableStringVisitor {
+            type Value = InlinableString;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string")
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where E: DeError
+            {
+                Ok(v.into())
+            }
+        }
+
+        deserializer.deserialize_any(InlinableStringVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use InlinableString;
+    use serde_test::{Token, assert_tokens};
+
+    #[test]
+    fn test_ser_de() {
+        let s = InlinableString::from("small");
+
+        assert_tokens(&s, &[Token::String("small")]);
+    }
+}


### PR DESCRIPTION
Closes #11 

This adds an optional `serde` feature for serialising/deserialising `InlinableString`s. The implementation is really simple; it just uses `Deref` for serialisation and `From` for deserialisation.