### PR TITLE
impl fmt::Write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "inlinable_string"
 
 description = "The `inlinable_string` crate provides the `InlinableString` type -- an owned, grow-able UTF-8 string that stores small strings inline and avoids heap-allocation -- and the `StringExt` trait which abstracts string operations over both `std::string::String` and `InlinableString` (or even your own custom string type)."
 
-version = "0.1.8"
+version = "0.1.9"
 license = "Apache-2.0/MIT"
 keywords = ["string", "inline", "inlinable"]
 readme = "./README.md"

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -131,6 +131,15 @@ impl fmt::Display for InlineString {
     }
 }
 
+impl fmt::Write for InlineString {
+    fn write_char(&mut self, ch: char) -> Result<(), fmt::Error> {
+        self.push(ch).map_err(|_| fmt::Error)
+    }
+    fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
+        self.push_str(s).map_err(|_| fmt::Error)
+    }
+}
+
 impl hash::Hash for InlineString {
     #[inline]
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
@@ -673,6 +682,19 @@ mod tests {
         }
 
         assert_eq!(s.insert(0, 'a'), Err(NotEnoughSpaceError));
+    }
+
+    #[test]
+    fn test_write() {
+        use fmt::{Error, Write};
+
+        let mut s = InlineString::new();
+
+        for _ in 0..INLINE_STRING_CAPACITY {
+            assert!(write!(&mut s, "a").is_ok());
+        }
+
+        assert_eq!(write!(&mut s, "a"), Err(Error));
     }
 }
 

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -689,12 +689,15 @@ mod tests {
         use fmt::{Error, Write};
 
         let mut s = InlineString::new();
+        let mut normal_string = String::new();
 
         for _ in 0..INLINE_STRING_CAPACITY {
             assert!(write!(&mut s, "a").is_ok());
+            assert!(write!(&mut normal_string, "a").is_ok());
         }
 
         assert_eq!(write!(&mut s, "a"), Err(Error));
+        assert_eq!(&normal_string[..], &s[..]);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,17 @@ impl fmt::Display for InlinableString {
     }
 }
 
+impl fmt::Write for InlinableString {
+    fn write_char(&mut self, ch: char) -> Result<(), fmt::Error> {
+        self.push(ch);
+        Ok(())
+    }
+    fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
+        self.push_str(s);
+        Ok(())
+    }
+}
+
 impl ops::Index<ops::Range<usize>> for InlinableString {
     type Output = str;
 
@@ -655,6 +666,19 @@ mod tests {
         let long_str = "this is a really long string that is much larger than
                         INLINE_STRING_CAPACITY and so cannot be stored inline.";
         s.push_str(long_str);
+        assert_eq!(s, String::from("small") + long_str);
+    }
+
+    #[test]
+    fn test_write() {
+        use fmt::Write;
+        let mut s = InlinableString::new();
+        write!(&mut s, "small").expect("!write");
+        assert_eq!(s, "small");
+
+        let long_str = "this is a really long string that is much larger than
+                        INLINE_STRING_CAPACITY and so cannot be stored inline.";
+        write!(&mut s, "{}", long_str).expect("!write");
         assert_eq!(s, String::from("small") + long_str);
     }
 


### PR DESCRIPTION
Implementing `fmt::Write` allows us to use the `InlinableString` for efficient integer-to-string conversions, for example.