### PR TITLE
Improve deserialize

### DIFF
--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -31,7 +31,7 @@ impl<'de> Deserialize<'de> for InlinableString {
             }
         }
 
-        deserializer.deserialize_any(InlinableStringVisitor)
+        deserializer.deserialize_str(InlinableStringVisitor)
     }
 }
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -29,6 +29,12 @@ impl<'de> Deserialize<'de> for InlinableString {
             {
                 Ok(v.into())
             }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+                where E: DeError
+            {
+                Ok(v.into())
+            }
         }
 
         deserializer.deserialize_str(InlinableStringVisitor)


### PR DESCRIPTION
Two improvements for deserialization:
 * Hint that we want string.
 * Take advantage of already allocated `String`, if that's what the `Deserializer` gives us.

More details in commit messages.