### PR TITLE
Fix clippy lint warnings

### DIFF
--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -48,9 +48,9 @@ use std::str;
 ///
 /// Sometime in the future, when Rust's generics support specializing with
 /// compile-time static integers, this number should become configurable.
-#[cfg(target_pointer_width="64")]
+#[cfg(target_pointer_width = "64")]
 pub const INLINE_STRING_CAPACITY: usize = 30;
-#[cfg(target_pointer_width="32")]
+#[cfg(target_pointer_width = "32")]
 pub const INLINE_STRING_CAPACITY: usize = 14;
 
 /// A short UTF-8 string that uses inline storage and does no heap allocation.
@@ -70,9 +70,7 @@ pub struct NotEnoughSpaceError;
 impl AsRef<str> for InlineString {
     fn as_ref(&self) -> &str {
         self.assert_sanity();
-        unsafe {
-            mem::transmute(&self.bytes[0..self.len()])
-        }
+        unsafe { mem::transmute(&self.bytes[0..self.len()]) }
     }
 }
 
@@ -87,9 +85,7 @@ impl AsMut<str> for InlineString {
     fn as_mut(&mut self) -> &mut str {
         self.assert_sanity();
         let length = self.len();
-        unsafe {
-            mem::transmute(&mut self.bytes[0..length])
-        }
+        unsafe { mem::transmute(&mut self.bytes[0..length]) }
     }
 }
 
@@ -183,9 +179,7 @@ impl ops::Index<ops::RangeFull> for InlineString {
     #[inline]
     fn index(&self, _index: ops::RangeFull) -> &str {
         self.assert_sanity();
-        unsafe {
-            mem::transmute(&self.bytes[0..self.len()])
-        }
+        unsafe { mem::transmute(&self.bytes[0..self.len()]) }
     }
 }
 
@@ -218,9 +212,7 @@ impl ops::IndexMut<ops::RangeFull> for InlineString {
     fn index_mut(&mut self, _index: ops::RangeFull) -> &mut str {
         self.assert_sanity();
         let length = self.len();
-        unsafe {
-            mem::transmute(&mut self.bytes[0..length])
-        }
+        unsafe { mem::transmute(&mut self.bytes[0..length]) }
     }
 }
 
@@ -230,9 +222,7 @@ impl ops::Deref for InlineString {
     #[inline]
     fn deref(&self) -> &str {
         self.assert_sanity();
-        unsafe {
-            mem::transmute(&self.bytes[0..self.len()])
-        }
+        unsafe { mem::transmute(&self.bytes[0..self.len()]) }
     }
 }
 
@@ -241,9 +231,7 @@ impl ops::DerefMut for InlineString {
     fn deref_mut(&mut self) -> &mut str {
         self.assert_sanity();
         let length = self.len();
-        unsafe {
-            mem::transmute(&mut self.bytes[0..length])
-        }
+        unsafe { mem::transmute(&mut self.bytes[0..length]) }
     }
 }
 
@@ -274,19 +262,26 @@ macro_rules! impl_eq {
     ($lhs:ty, $rhs: ty) => {
         impl<'a> PartialEq<$rhs> for $lhs {
             #[inline]
-            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
+            fn eq(&self, other: &$rhs) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
             #[inline]
-            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
+            fn ne(&self, other: &$rhs) -> bool {
+                PartialEq::ne(&self[..], &other[..])
+            }
         }
 
         impl<'a> PartialEq<$lhs> for $rhs {
             #[inline]
-            fn eq(&self, other: &$lhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
+            fn eq(&self, other: &$lhs) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
             #[inline]
-            fn ne(&self, other: &$lhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
+            fn ne(&self, other: &$lhs) -> bool {
+                PartialEq::ne(&self[..], &other[..])
+            }
         }
-
-    }
+    };
 }
 
 impl_eq! { InlineString, str }
@@ -297,10 +292,14 @@ impl InlineString {
     #[cfg_attr(feature = "nightly", allow(inline_always))]
     #[inline(always)]
     fn assert_sanity(&self) {
-        debug_assert!(self.length as usize <= INLINE_STRING_CAPACITY,
-                      "inlinable_string: internal error: length greater than capacity");
-        debug_assert!(str::from_utf8(&self.bytes[0..self.length as usize]).is_ok(),
-                      "inlinable_string: internal error: contents are not valid UTF-8!");
+        debug_assert!(
+            self.length as usize <= INLINE_STRING_CAPACITY,
+            "inlinable_string: internal error: length greater than capacity"
+        );
+        debug_assert!(
+            str::from_utf8(&self.bytes[0..self.length as usize]).is_ok(),
+            "inlinable_string: internal error: contents are not valid UTF-8!"
+        );
     }
 
     /// Creates a new string buffer initialized with the empty string.
@@ -364,9 +363,11 @@ impl InlineString {
         }
 
         unsafe {
-            ptr::copy_nonoverlapping(string.as_ptr(),
-                      self.bytes.as_mut_ptr().offset(self.length as isize),
-                      string_len);
+            ptr::copy_nonoverlapping(
+                string.as_ptr(),
+                self.bytes.as_mut_ptr().offset(self.length as isize),
+                string_len,
+            );
         }
         self.length = new_length as u8;
 
@@ -400,9 +401,10 @@ impl InlineString {
 
         {
             let mut slice = &mut self.bytes[self.length as usize..INLINE_STRING_CAPACITY];
-            write!(&mut slice, "{}", ch)
-                .expect("inlinable_string: internal error: should have enough space, we
-                         checked above");
+            write!(&mut slice, "{}", ch).expect(
+                "inlinable_string: internal error: should have enough space, we
+                         checked above",
+            );
         }
         self.length = new_length as u8;
 
@@ -446,9 +448,14 @@ impl InlineString {
     pub fn truncate(&mut self, new_len: usize) {
         self.assert_sanity();
 
-        assert!(self.char_indices().filter(|&(i, _)| i == new_len).next().is_some(),
-                "inlinable_string::InlineString::truncate: new_len is not a character
-                 boundary");
+        assert!(
+            self.char_indices()
+                .filter(|&(i, _)| i == new_len)
+                .next()
+                .is_some(),
+            "inlinable_string::InlineString::truncate: new_len is not a character
+                 boundary"
+        );
         assert!(new_len <= self.len());
 
         self.length = new_len as u8;
@@ -507,16 +514,20 @@ impl InlineString {
         assert!(idx <= self.len());
 
         match self.char_indices().filter(|&(i, _)| i == idx).next() {
-            None => panic!("inlinable_string::InlineString::remove: idx does not lie on a
-                            character boundary"),
+            None => panic!(
+                "inlinable_string::InlineString::remove: idx does not lie on a
+                            character boundary"
+            ),
             Some((_, ch)) => {
                 let char_len = ch.len_utf8();
                 let next = idx + char_len;
 
                 unsafe {
-                    ptr::copy(self.bytes.as_ptr().offset(next as isize),
-                              self.bytes.as_mut_ptr().offset(idx as isize),
-                              self.len() - next);
+                    ptr::copy(
+                        self.bytes.as_ptr().offset(next as isize),
+                        self.bytes.as_mut_ptr().offset(idx as isize),
+                        self.len() - next,
+                    );
                 }
                 self.length = self.length - char_len as u8;
 
@@ -555,13 +566,16 @@ impl InlineString {
         }
 
         unsafe {
-            ptr::copy(self.bytes.as_ptr().offset(idx as isize),
-                      self.bytes.as_mut_ptr().offset((idx + char_len) as isize),
-                      self.len() - idx);
+            ptr::copy(
+                self.bytes.as_ptr().offset(idx as isize),
+                self.bytes.as_mut_ptr().offset((idx + char_len) as isize),
+                self.len() - idx,
+            );
             let mut slice = &mut self.bytes[idx..idx + char_len];
-            write!(&mut slice, "{}", ch)
-                .expect("inlinable_string: internal error: we should have enough space, we
-                         checked above");
+            write!(&mut slice, "{}", ch).expect(
+                "inlinable_string: internal error: we should have enough space, we
+                         checked above",
+            );
         }
         self.length = new_length as u8;
 
@@ -707,6 +721,5 @@ mod benches {
     use test::Bencher;
 
     #[bench]
-    fn its_fast(b: &mut Bencher) {
-    }
+    fn its_fast(b: &mut Bencher) {}
 }

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -38,7 +38,6 @@ use std::borrow;
 use std::fmt;
 use std::hash;
 use std::io::Write;
-use std::mem;
 use std::ops;
 use std::ptr;
 use std::str;
@@ -70,7 +69,7 @@ pub struct NotEnoughSpaceError;
 impl AsRef<str> for InlineString {
     fn as_ref(&self) -> &str {
         self.assert_sanity();
-        unsafe { mem::transmute(&self.bytes[0..self.len()]) }
+        unsafe { str::from_utf8_unchecked(&self.bytes[..self.len()]) }
     }
 }
 
@@ -85,7 +84,7 @@ impl AsMut<str> for InlineString {
     fn as_mut(&mut self) -> &mut str {
         self.assert_sanity();
         let length = self.len();
-        unsafe { mem::transmute(&mut self.bytes[0..length]) }
+        unsafe { str::from_utf8_unchecked_mut(&mut self.bytes[..length]) }
     }
 }
 
@@ -179,7 +178,7 @@ impl ops::Index<ops::RangeFull> for InlineString {
     #[inline]
     fn index(&self, _index: ops::RangeFull) -> &str {
         self.assert_sanity();
-        unsafe { mem::transmute(&self.bytes[0..self.len()]) }
+        unsafe { str::from_utf8_unchecked(&self.bytes[..self.len()]) }
     }
 }
 
@@ -212,7 +211,7 @@ impl ops::IndexMut<ops::RangeFull> for InlineString {
     fn index_mut(&mut self, _index: ops::RangeFull) -> &mut str {
         self.assert_sanity();
         let length = self.len();
-        unsafe { mem::transmute(&mut self.bytes[0..length]) }
+        unsafe { str::from_utf8_unchecked_mut(&mut self.bytes[..length]) }
     }
 }
 
@@ -222,7 +221,7 @@ impl ops::Deref for InlineString {
     #[inline]
     fn deref(&self) -> &str {
         self.assert_sanity();
-        unsafe { mem::transmute(&self.bytes[0..self.len()]) }
+        unsafe { str::from_utf8_unchecked(&self.bytes[..self.len()]) }
     }
 }
 
@@ -231,7 +230,7 @@ impl ops::DerefMut for InlineString {
     fn deref_mut(&mut self) -> &mut str {
         self.assert_sanity();
         let length = self.len();
-        unsafe { mem::transmute(&mut self.bytes[0..length]) }
+        unsafe { str::from_utf8_unchecked_mut(&mut self.bytes[..length]) }
     }
 }
 

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -566,6 +566,8 @@ impl InlineString {
 
     /// Views the internal string buffer as a mutable sequence of bytes.
     ///
+    /// # Safety
+    ///
     /// This is unsafe because it does not check to ensure that the resulting
     /// string will be valid UTF-8.
     ///

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -249,13 +249,6 @@ impl PartialEq<InlineString> for InlineString {
         rhs.assert_sanity();
         PartialEq::eq(&self[..], &rhs[..])
     }
-
-    #[inline]
-    fn ne(&self, rhs: &InlineString) -> bool {
-        self.assert_sanity();
-        rhs.assert_sanity();
-        PartialEq::ne(&self[..], &rhs[..])
-    }
 }
 
 macro_rules! impl_eq {
@@ -265,20 +258,12 @@ macro_rules! impl_eq {
             fn eq(&self, other: &$rhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
             }
-            #[inline]
-            fn ne(&self, other: &$rhs) -> bool {
-                PartialEq::ne(&self[..], &other[..])
-            }
         }
 
         impl<'a> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
-            }
-            #[inline]
-            fn ne(&self, other: &$lhs) -> bool {
-                PartialEq::ne(&self[..], &other[..])
             }
         }
     };

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -434,10 +434,7 @@ impl InlineString {
         self.assert_sanity();
 
         assert!(
-            self.char_indices()
-                .filter(|&(i, _)| i == new_len)
-                .next()
-                .is_some(),
+            self.char_indices().any(|(i, _)| i == new_len),
             "inlinable_string::InlineString::truncate: new_len is not a character
                  boundary"
         );
@@ -498,7 +495,7 @@ impl InlineString {
         self.assert_sanity();
         assert!(idx <= self.len());
 
-        match self.char_indices().filter(|&(i, _)| i == idx).next() {
+        match self.char_indices().find(|&(i, _)| i == idx) {
             None => panic!(
                 "inlinable_string::InlineString::remove: idx does not lie on a
                             character boundary"

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -506,8 +506,8 @@ impl InlineString {
 
                 unsafe {
                     ptr::copy(
-                        self.bytes.as_ptr().offset(next as isize),
-                        self.bytes.as_mut_ptr().offset(idx as isize),
+                        self.bytes.as_ptr().add(next),
+                        self.bytes.as_mut_ptr().add(idx),
                         self.len() - next,
                     );
                 }
@@ -549,8 +549,8 @@ impl InlineString {
 
         unsafe {
             ptr::copy(
-                self.bytes.as_ptr().offset(idx as isize),
-                self.bytes.as_mut_ptr().offset((idx + char_len) as isize),
+                self.bytes.as_ptr().add(idx),
+                self.bytes.as_mut_ptr().add(idx + char_len),
                 self.len() - idx,
             );
             let mut slice = &mut self.bytes[idx..idx + char_len];

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -511,7 +511,7 @@ impl InlineString {
                         self.len() - next,
                     );
                 }
-                self.length = self.length - char_len as u8;
+                self.length -= char_len as u8;
 
                 self.assert_sanity();
                 ch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,20 +65,18 @@
 //! consider using the more restrictive
 //! [`InlineString`](./inline_string/struct.InlineString.html) type. If `member` is
 //! not always small, then it should probably be left as a `String`.
-//! 
+//!
 //! # Serialization
-//! 
+//!
 //! `InlinableString` implements [`serde`][serde-docs]'s `Serialize` and `Deserialize` traits.
 //! Add the `serde` feature to your `Cargo.toml` to enable serialization.
-//! 
+//!
 //! [serde-docs]: https://serde.rs
 
 #![forbid(missing_docs)]
-
 #![cfg_attr(feature = "nightly", feature(plugin))]
 #![cfg_attr(feature = "nightly", plugin(clippy))]
 #![cfg_attr(feature = "nightly", deny(clippy))]
-
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
 #[cfg(feature = "serde")]
@@ -97,7 +95,7 @@ mod serde_impl;
 pub mod inline_string;
 pub mod string_ext;
 
-pub use inline_string::{INLINE_STRING_CAPACITY, InlineString};
+pub use inline_string::{InlineString, INLINE_STRING_CAPACITY};
 pub use string_ext::StringExt;
 
 use std::borrow::{Borrow, Cow};
@@ -107,7 +105,7 @@ use std::hash;
 use std::iter;
 use std::mem;
 use std::ops;
-use std::string::{FromUtf8Error, FromUtf16Error};
+use std::string::{FromUtf16Error, FromUtf8Error};
 
 /// An owned, grow-able UTF-8 string that allocates short strings inline on the
 /// stack.
@@ -128,7 +126,7 @@ impl fmt::Debug for InlinableString {
 }
 
 impl iter::FromIterator<char> for InlinableString {
-    fn from_iter<I: IntoIterator<Item=char>>(iter: I) -> InlinableString {
+    fn from_iter<I: IntoIterator<Item = char>>(iter: I) -> InlinableString {
         let mut buf = InlinableString::new();
         buf.extend(iter);
         buf
@@ -136,7 +134,7 @@ impl iter::FromIterator<char> for InlinableString {
 }
 
 impl<'a> iter::FromIterator<&'a str> for InlinableString {
-    fn from_iter<I: IntoIterator<Item=&'a str>>(iter: I) -> InlinableString {
+    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> InlinableString {
         let mut buf = InlinableString::new();
         buf.extend(iter);
         buf
@@ -144,7 +142,7 @@ impl<'a> iter::FromIterator<&'a str> for InlinableString {
 }
 
 impl Extend<char> for InlinableString {
-    fn extend<I: IntoIterator<Item=char>>(&mut self, iterable: I) {
+    fn extend<I: IntoIterator<Item = char>>(&mut self, iterable: I) {
         let iterator = iterable.into_iter();
         let (lower_bound, _) = iterator.size_hint();
         self.reserve(lower_bound);
@@ -155,13 +153,13 @@ impl Extend<char> for InlinableString {
 }
 
 impl<'a> Extend<&'a char> for InlinableString {
-    fn extend<I: IntoIterator<Item=&'a char>>(&mut self, iter: I) {
+    fn extend<I: IntoIterator<Item = &'a char>>(&mut self, iter: I) {
         self.extend(iter.into_iter().cloned());
     }
 }
 
 impl<'a> Extend<&'a str> for InlinableString {
-    fn extend<I: IntoIterator<Item=&'a str>>(&mut self, iterable: I) {
+    fn extend<I: IntoIterator<Item = &'a str>>(&mut self, iterable: I) {
         let iterator = iterable.into_iter();
         let (lower_bound, _) = iterator.size_hint();
         self.reserve(lower_bound);
@@ -399,19 +397,26 @@ macro_rules! impl_eq {
     ($lhs:ty, $rhs: ty) => {
         impl<'a> PartialEq<$rhs> for $lhs {
             #[inline]
-            fn eq(&self, other: &$rhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
+            fn eq(&self, other: &$rhs) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
             #[inline]
-            fn ne(&self, other: &$rhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
+            fn ne(&self, other: &$rhs) -> bool {
+                PartialEq::ne(&self[..], &other[..])
+            }
         }
 
         impl<'a> PartialEq<$lhs> for $rhs {
             #[inline]
-            fn eq(&self, other: &$lhs) -> bool { PartialEq::eq(&self[..], &other[..]) }
+            fn eq(&self, other: &$lhs) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
             #[inline]
-            fn ne(&self, other: &$lhs) -> bool { PartialEq::ne(&self[..], &other[..]) }
+            fn ne(&self, other: &$lhs) -> bool {
+                PartialEq::ne(&self[..], &other[..])
+            }
         }
-
-    }
+    };
 }
 
 impl_eq! { InlinableString, str }
@@ -479,11 +484,11 @@ impl<'a> StringExt<'a> for InlinableString {
                 promoted.push_str(&*s);
                 promoted.push_str(string);
                 promoted
-            },
+            }
             InlinableString::Heap(ref mut s) => {
                 s.push_str(string);
                 return;
-            },
+            }
         };
         mem::swap(self, &mut InlinableString::Heap(promoted));
     }
@@ -507,11 +512,11 @@ impl<'a> StringExt<'a> for InlinableString {
                 let mut promoted = String::with_capacity(new_capacity);
                 promoted.push_str(&s);
                 promoted
-            },
+            }
             InlinableString::Heap(ref mut s) => {
                 s.reserve(additional);
                 return;
-            },
+            }
         };
         mem::swap(self, &mut InlinableString::Heap(promoted));
     }
@@ -527,11 +532,11 @@ impl<'a> StringExt<'a> for InlinableString {
                 let mut promoted = String::with_capacity(new_capacity);
                 promoted.push_str(&s);
                 promoted
-            },
+            }
             InlinableString::Heap(ref mut s) => {
                 s.reserve_exact(additional);
                 return;
-            },
+            }
         };
         mem::swap(self, &mut InlinableString::Heap(promoted));
     }
@@ -566,11 +571,11 @@ impl<'a> StringExt<'a> for InlinableString {
                 promoted.push_str(&*s);
                 promoted.push(ch);
                 promoted
-            },
+            }
             InlinableString::Heap(ref mut s) => {
                 s.push(ch);
                 return;
-            },
+            }
         };
 
         mem::swap(self, &mut InlinableString::Heap(promoted));
@@ -614,7 +619,7 @@ impl<'a> StringExt<'a> for InlinableString {
             InlinableString::Heap(ref mut s) => {
                 s.insert(idx, ch);
                 return;
-            },
+            }
             InlinableString::Inline(ref mut s) => {
                 if s.insert(idx, ch).is_ok() {
                     return;
@@ -625,7 +630,7 @@ impl<'a> StringExt<'a> for InlinableString {
                 promoted.push(ch);
                 promoted.push_str(&s[idx..]);
                 promoted
-            },
+            }
         };
 
         mem::swap(self, &mut InlinableString::Heap(promoted));
@@ -697,7 +702,10 @@ mod tests {
         }
         s.push('a');
 
-        assert_eq!(s, String::from_iter((0..INLINE_STRING_CAPACITY + 1).map(|_| 'a')));
+        assert_eq!(
+            s,
+            String::from_iter((0..INLINE_STRING_CAPACITY + 1).map(|_| 'a'))
+        );
     }
 
     #[test]
@@ -709,7 +717,10 @@ mod tests {
         }
         s.insert(0, 'a');
 
-        assert_eq!(s, String::from_iter((0..INLINE_STRING_CAPACITY + 1).map(|_| 'a')));
+        assert_eq!(
+            s,
+            String::from_iter((0..INLINE_STRING_CAPACITY + 1).map(|_| 'a'))
+        );
     }
 
     // Next, some general sanity tests.
@@ -734,8 +745,7 @@ mod tests {
 
     #[test]
     fn test_from_utf16() {
-        let v = &mut [0xD834, 0xDD1E, 0x006d, 0x0075,
-                      0x0073, 0x0069, 0x0063];
+        let v = &mut [0xD834, 0xDD1E, 0x006d, 0x0075, 0x0073, 0x0069, 0x0063];
         let s = <InlinableString as StringExt>::from_utf16(v);
         assert_eq!(s.unwrap(), "𝄞music");
     }
@@ -805,7 +815,7 @@ mod tests {
         assert_eq!(Ord::cmp(&s1, &s2), Ordering::Greater);
         assert_eq!(Ord::cmp(&s1, &s1), Ordering::Equal);
     }
-    
+
     #[test]
     fn test_display() {
         let short = InlinableString::from("he");
@@ -813,13 +823,16 @@ mod tests {
         assert_eq!(format!("{}", short), "he".to_string());
         assert_eq!(format!("{}", long), "hello world".to_string());
     }
-    
+
     #[test]
     fn test_debug() {
         let short = InlinableString::from("he");
         let long = InlinableString::from("hello world hello world hello world");
         assert_eq!(format!("{:?}", short), "\"he\"");
-        assert_eq!(format!("{:?}", long), "\"hello world hello world hello world\"");
+        assert_eq!(
+            format!("{:?}", long),
+            "\"hello world hello world hello world\""
+        );
     }
 }
 
@@ -827,7 +840,7 @@ mod tests {
 #[cfg(feature = "nightly")]
 mod benches {
     use super::{InlinableString, StringExt};
-    use test::{Bencher, black_box};
+    use test::{black_box, Bencher};
 
     const SMALL_STR: &'static str = "foobar";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,11 +386,6 @@ impl PartialEq<InlinableString> for InlinableString {
     fn eq(&self, rhs: &InlinableString) -> bool {
         PartialEq::eq(&self[..], &rhs[..])
     }
-
-    #[inline]
-    fn ne(&self, rhs: &InlinableString) -> bool {
-        PartialEq::ne(&self[..], &rhs[..])
-    }
 }
 
 macro_rules! impl_eq {
@@ -400,20 +395,12 @@ macro_rules! impl_eq {
             fn eq(&self, other: &$rhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
             }
-            #[inline]
-            fn ne(&self, other: &$rhs) -> bool {
-                PartialEq::ne(&self[..], &other[..])
-            }
         }
 
         impl<'a> PartialEq<$lhs> for $rhs {
             #[inline]
             fn eq(&self, other: &$lhs) -> bool {
                 PartialEq::eq(&self[..], &other[..])
-            }
-            #[inline]
-            fn ne(&self, other: &$lhs) -> bool {
-                PartialEq::ne(&self[..], &other[..])
             }
         }
     };

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,11 +1,12 @@
-use std::fmt;
+use serde::de::{Deserialize, Deserializer, Error as DeError, Visitor};
 use serde::{Serialize, Serializer};
-use serde::de::{Deserialize, Deserializer, Visitor, Error as DeError};
+use std::fmt;
 use InlinableString;
 
 impl Serialize for InlinableString {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> 
-        where S: Serializer
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
     {
         serializer.serialize_str(self)
     }
@@ -13,7 +14,8 @@ impl Serialize for InlinableString {
 
 impl<'de> Deserialize<'de> for InlinableString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         struct InlinableStringVisitor;
 
@@ -25,13 +27,15 @@ impl<'de> Deserialize<'de> for InlinableString {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                where E: DeError
+            where
+                E: DeError,
             {
                 Ok(v.into())
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
-                where E: DeError
+            where
+                E: DeError,
             {
                 Ok(v.into())
             }
@@ -43,8 +47,8 @@ impl<'de> Deserialize<'de> for InlinableString {
 
 #[cfg(test)]
 mod tests {
+    use serde_test::{assert_tokens, Token};
     use InlinableString;
-    use serde_test::{Token, assert_tokens};
 
     #[test]
     fn test_ser_de() {

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -38,7 +38,6 @@ pub trait StringExt<'a>:
     ///
     /// let s = InlinableString::new();
     /// ```
-    #[inline]
     fn new() -> Self
     where
         Self: Sized;
@@ -55,7 +54,6 @@ pub trait StringExt<'a>:
     ///
     /// let s = InlinableString::with_capacity(10);
     /// ```
-    #[inline]
     fn with_capacity(capacity: usize) -> Self
     where
         Self: Sized;
@@ -82,7 +80,6 @@ pub trait StringExt<'a>:
     /// let err = s.utf8_error();
     /// assert_eq!(s.into_bytes(), [240, 144, 128]);
     /// ```
-    #[inline]
     fn from_utf8(vec: Vec<u8>) -> Result<Self, FromUtf8Error>
     where
         Self: Sized;
@@ -144,7 +141,6 @@ pub trait StringExt<'a>:
     /// assert_eq!(InlinableString::from_utf16_lossy(v),
     ///            InlinableString::from("𝄞mus\u{FFFD}ic\u{FFFD}"));
     /// ```
-    #[inline]
     fn from_utf16_lossy(v: &[u16]) -> Self
     where
         Self: Sized;
@@ -161,7 +157,6 @@ pub trait StringExt<'a>:
     ///   for the invariants it expects, they also apply to this function.
     ///
     /// * We assume that the `Vec` contains valid UTF-8.
-    #[inline]
     unsafe fn from_raw_parts(buf: *mut u8, length: usize, capacity: usize) -> Self
     where
         Self: Sized;
@@ -169,7 +164,6 @@ pub trait StringExt<'a>:
     /// Converts a vector of bytes to a new `InlinableString` without checking
     /// if it contains valid UTF-8. This is unsafe because it assumes that the
     /// UTF-8-ness of the vector has already been validated.
-    #[inline]
     unsafe fn from_utf8_unchecked(bytes: Vec<u8>) -> Self
     where
         Self: Sized;
@@ -185,7 +179,6 @@ pub trait StringExt<'a>:
     /// let bytes = s.into_bytes();
     /// assert_eq!(bytes, [104, 101, 108, 108, 111]);
     /// ```
-    #[inline]
     fn into_bytes(self) -> Vec<u8>;
 
     /// Pushes the given string onto this string buffer.
@@ -199,7 +192,6 @@ pub trait StringExt<'a>:
     /// s.push_str("bar");
     /// assert_eq!(s, "foobar");
     /// ```
-    #[inline]
     fn push_str(&mut self, string: &str);
 
     /// Returns the number of bytes that this string buffer can hold without
@@ -213,7 +205,6 @@ pub trait StringExt<'a>:
     /// let s = InlinableString::with_capacity(10);
     /// assert!(s.capacity() >= 10);
     /// ```
-    #[inline]
     fn capacity(&self) -> usize;
 
     /// Reserves capacity for at least `additional` more bytes to be inserted
@@ -233,7 +224,6 @@ pub trait StringExt<'a>:
     /// s.reserve(10);
     /// assert!(s.capacity() >= 10);
     /// ```
-    #[inline]
     fn reserve(&mut self, additional: usize);
 
     /// Reserves the minimum capacity for exactly `additional` more bytes to be
@@ -257,7 +247,6 @@ pub trait StringExt<'a>:
     /// s.reserve_exact(10);
     /// assert!(s.capacity() >= 10);
     /// ```
-    #[inline]
     fn reserve_exact(&mut self, additional: usize);
 
     /// Shrinks the capacity of this string buffer to match its length. If the
@@ -275,7 +264,6 @@ pub trait StringExt<'a>:
     /// s.shrink_to_fit();
     /// assert_eq!(s.capacity(), inlinable_string::INLINE_STRING_CAPACITY);
     /// ```
-    #[inline]
     fn shrink_to_fit(&mut self);
 
     /// Adds the given character to the end of the string.
@@ -291,7 +279,6 @@ pub trait StringExt<'a>:
     /// s.push('3');
     /// assert_eq!(s, "abc123");
     /// ```
-    #[inline]
     fn push(&mut self, ch: char);
 
     /// Works with the underlying buffer as a byte slice.
@@ -304,7 +291,6 @@ pub trait StringExt<'a>:
     /// let s = InlinableString::from("hello");
     /// assert_eq!(s.as_bytes(), [104, 101, 108, 108, 111]);
     /// ```
-    #[inline]
     fn as_bytes(&self) -> &[u8];
 
     /// Shortens a string to the specified length.
@@ -323,7 +309,6 @@ pub trait StringExt<'a>:
     /// s.truncate(2);
     /// assert_eq!(s, "he");
     /// ```
-    #[inline]
     fn truncate(&mut self, new_len: usize);
 
     /// Removes the last character from the string buffer and returns it.
@@ -340,7 +325,6 @@ pub trait StringExt<'a>:
     /// assert_eq!(s.pop(), Some('f'));
     /// assert_eq!(s.pop(), None);
     /// ```
-    #[inline]
     fn pop(&mut self) -> Option<char>;
 
     /// Removes the character from the string buffer at byte position `idx` and
@@ -366,7 +350,6 @@ pub trait StringExt<'a>:
     /// assert_eq!(s.remove(1), 'o');
     /// assert_eq!(s.remove(0), 'o');
     /// ```
-    #[inline]
     fn remove(&mut self, idx: usize) -> char;
 
     /// Inserts a character into the string buffer at byte position `idx`.
@@ -390,7 +373,6 @@ pub trait StringExt<'a>:
     ///
     /// If `idx` does not lie on a character boundary or is out of bounds, then
     /// this function will panic.
-    #[inline]
     fn insert(&mut self, idx: usize, ch: char);
 
     /// Views the string buffer as a mutable sequence of bytes.
@@ -411,7 +393,6 @@ pub trait StringExt<'a>:
     /// }
     /// assert_eq!(s, "olleh");
     /// ```
-    #[inline]
     unsafe fn as_mut_slice(&mut self) -> &mut [u8];
 
     /// Returns the number of bytes in this string.
@@ -424,7 +405,6 @@ pub trait StringExt<'a>:
     /// let a = InlinableString::from("foo");
     /// assert_eq!(a.len(), 3);
     /// ```
-    #[inline]
     fn len(&self) -> usize;
 
     /// Returns true if the string contains no bytes

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -15,15 +15,19 @@ use std::borrow::{Borrow, Cow};
 use std::cmp::PartialEq;
 use std::fmt::Display;
 use std::mem;
-use std::string::{FromUtf8Error, FromUtf16Error};
+use std::string::{FromUtf16Error, FromUtf8Error};
 
 /// A trait that exists to abstract string operations over any number of
 /// concrete string type implementations.
 ///
 /// See the [crate level documentation](./../index.html) for more.
 pub trait StringExt<'a>:
-    Borrow<str> + Display + PartialEq<str> + PartialEq<&'a str> + PartialEq<String> +
-    PartialEq<Cow<'a, str>>
+    Borrow<str>
+    + Display
+    + PartialEq<str>
+    + PartialEq<&'a str>
+    + PartialEq<String>
+    + PartialEq<Cow<'a, str>>
 {
     /// Creates a new string buffer initialized with the empty string.
     ///
@@ -35,7 +39,9 @@ pub trait StringExt<'a>:
     /// let s = InlinableString::new();
     /// ```
     #[inline]
-    fn new() -> Self where Self: Sized;
+    fn new() -> Self
+    where
+        Self: Sized;
 
     /// Creates a new string buffer with the given capacity. The string will be
     /// able to hold at least `capacity` bytes without reallocating. If
@@ -50,7 +56,9 @@ pub trait StringExt<'a>:
     /// let s = InlinableString::with_capacity(10);
     /// ```
     #[inline]
-    fn with_capacity(capacity: usize) -> Self where Self: Sized;
+    fn with_capacity(capacity: usize) -> Self
+    where
+        Self: Sized;
 
     /// Returns the vector as a string buffer, if possible, taking care not to
     /// copy it.
@@ -75,7 +83,9 @@ pub trait StringExt<'a>:
     /// assert_eq!(s.into_bytes(), [240, 144, 128]);
     /// ```
     #[inline]
-    fn from_utf8(vec: Vec<u8>) -> Result<Self, FromUtf8Error>  where Self: Sized;
+    fn from_utf8(vec: Vec<u8>) -> Result<Self, FromUtf8Error>
+    where
+        Self: Sized;
 
     /// Converts a vector of bytes to a new UTF-8 string.
     /// Any invalid UTF-8 sequences are replaced with U+FFFD REPLACEMENT CHARACTER.
@@ -89,7 +99,10 @@ pub trait StringExt<'a>:
     /// let output = InlinableString::from_utf8_lossy(input);
     /// assert_eq!(output, "Hello \u{FFFD}World");
     /// ```
-    fn from_utf8_lossy(v: &'a [u8]) -> Cow<'a, str> where Self: Sized {
+    fn from_utf8_lossy(v: &'a [u8]) -> Cow<'a, str>
+    where
+        Self: Sized,
+    {
         String::from_utf8_lossy(v)
     }
 
@@ -111,7 +124,9 @@ pub trait StringExt<'a>:
     /// v[4] = 0xD800;
     /// assert!(InlinableString::from_utf16(v).is_err());
     /// ```
-    fn from_utf16(v: &[u16]) -> Result<Self, FromUtf16Error> where Self: Sized;
+    fn from_utf16(v: &[u16]) -> Result<Self, FromUtf16Error>
+    where
+        Self: Sized;
 
     /// Decode a UTF-16 encoded vector `v` into a string, replacing
     /// invalid data with the replacement character (U+FFFD).
@@ -130,7 +145,9 @@ pub trait StringExt<'a>:
     ///            InlinableString::from("𝄞mus\u{FFFD}ic\u{FFFD}"));
     /// ```
     #[inline]
-    fn from_utf16_lossy(v: &[u16]) -> Self where Self: Sized;
+    fn from_utf16_lossy(v: &[u16]) -> Self
+    where
+        Self: Sized;
 
     /// Creates a new `InlinableString` from a length, capacity, and pointer.
     ///
@@ -145,13 +162,17 @@ pub trait StringExt<'a>:
     ///
     /// * We assume that the `Vec` contains valid UTF-8.
     #[inline]
-    unsafe fn from_raw_parts(buf: *mut u8, length: usize, capacity: usize) -> Self where Self: Sized;
+    unsafe fn from_raw_parts(buf: *mut u8, length: usize, capacity: usize) -> Self
+    where
+        Self: Sized;
 
     /// Converts a vector of bytes to a new `InlinableString` without checking
     /// if it contains valid UTF-8. This is unsafe because it assumes that the
     /// UTF-8-ness of the vector has already been validated.
     #[inline]
-    unsafe fn from_utf8_unchecked(bytes: Vec<u8>) -> Self where Self: Sized;
+    unsafe fn from_utf8_unchecked(bytes: Vec<u8>) -> Self
+    where
+        Self: Sized;
 
     /// Returns the underlying byte buffer, encoded as UTF-8.
     ///
@@ -419,7 +440,9 @@ pub trait StringExt<'a>:
     /// assert!(!v.is_empty());
     /// ```
     #[inline]
-    fn is_empty(&self) -> bool { self.len() == 0 }
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Truncates the string, returning it to 0 length.
     ///
@@ -433,15 +456,21 @@ pub trait StringExt<'a>:
     /// assert!(s.is_empty());
     /// ```
     #[inline]
-    fn clear(&mut self) { self.truncate(0); }
+    fn clear(&mut self) {
+        self.truncate(0);
+    }
 }
 
 impl<'a> StringExt<'a> for String {
     #[inline]
-    fn new() -> Self { String::new() }
+    fn new() -> Self {
+        String::new()
+    }
 
     #[inline]
-    fn with_capacity(capacity: usize) -> Self { String::with_capacity(capacity) }
+    fn with_capacity(capacity: usize) -> Self {
+        String::with_capacity(capacity)
+    }
 
     #[inline]
     fn from_utf8(vec: Vec<u8>) -> Result<Self, FromUtf8Error> {
@@ -534,7 +563,9 @@ impl<'a> StringExt<'a> for String {
     }
 
     #[inline]
-    fn len(&self) -> usize { String::len(self) }
+    fn len(&self) -> usize {
+        String::len(self)
+    }
 }
 
 #[cfg(test)]
@@ -563,8 +594,7 @@ mod std_string_stringext_sanity_tests {
 
     #[test]
     fn test_from_utf16() {
-        let v = &mut [0xD834, 0xDD1E, 0x006d, 0x0075,
-                      0x0073, 0x0069, 0x0063];
+        let v = &mut [0xD834, 0xDD1E, 0x006d, 0x0075, 0x0073, 0x0069, 0x0063];
         let s = <String as StringExt>::from_utf16(v);
         assert_eq!(s.unwrap(), "𝄞music");
     }

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -14,7 +14,6 @@
 use std::borrow::{Borrow, Cow};
 use std::cmp::PartialEq;
 use std::fmt::Display;
-use std::mem;
 use std::string::{FromUtf16Error, FromUtf8Error};
 
 /// A trait that exists to abstract string operations over any number of
@@ -539,7 +538,7 @@ impl<'a> StringExt<'a> for String {
 
     #[inline]
     unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
-        mem::transmute(&mut **self)
+        &mut *(self.as_mut_str() as *mut str as *mut [u8])
     }
 
     #[inline]

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -146,7 +146,7 @@ pub trait StringExt<'a>:
 
     /// Creates a new `InlinableString` from a length, capacity, and pointer.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
     /// This is _very_ unsafe because:
     ///
@@ -161,8 +161,12 @@ pub trait StringExt<'a>:
         Self: Sized;
 
     /// Converts a vector of bytes to a new `InlinableString` without checking
-    /// if it contains valid UTF-8. This is unsafe because it assumes that the
-    /// UTF-8-ness of the vector has already been validated.
+    /// if it contains valid UTF-8.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because it assumes that the UTF-8-ness of the vector has
+    /// already been validated.
     unsafe fn from_utf8_unchecked(bytes: Vec<u8>) -> Self
     where
         Self: Sized;
@@ -375,6 +379,8 @@ pub trait StringExt<'a>:
     fn insert(&mut self, idx: usize, ch: char);
 
     /// Views the string buffer as a mutable sequence of bytes.
+    ///
+    /// # Safety
     ///
     /// This is unsafe because it does not check to ensure that the resulting
     /// string will be valid UTF-8.


### PR DESCRIPTION
This pull request fixes clippy lints.

I think it is better to let CI ensure there are no lint warnings, but this PR does not contain such change.

This PR should be rebased onto #21.