### PR TITLE
Use Rust edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ name = "inlinable_string"
 description = "The `inlinable_string` crate provides the `InlinableString` type -- an owned, grow-able UTF-8 string that stores small strings inline and avoids heap-allocation -- and the `StringExt` trait which abstracts string operations over both `std::string::String` and `InlinableString` (or even your own custom string type)."
 
 version = "0.1.11"
+edition = "2018"
 license = "Apache-2.0/MIT"
 keywords = ["string", "inline", "inlinable"]
 readme = "./README.md"

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -120,7 +120,7 @@ impl<'a> From<&'a str> for InlineString {
 }
 
 impl fmt::Display for InlineString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         self.assert_sanity();
         write!(f, "{}", self as &str)
     }
@@ -683,7 +683,7 @@ mod tests {
 
     #[test]
     fn test_write() {
-        use fmt::{Error, Write};
+        use std::fmt::{Error, Write};
 
         let mut s = InlineString::new();
         let mut normal_string = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,12 +79,6 @@
 #![cfg_attr(feature = "nightly", deny(clippy))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
-#[cfg(feature = "serde")]
-extern crate serde;
-
-#[cfg(all(test, feature = "serde"))]
-extern crate serde_test;
-
 #[cfg(test)]
 #[cfg(feature = "nightly")]
 extern crate test;
@@ -120,7 +114,7 @@ pub enum InlinableString {
 }
 
 impl fmt::Debug for InlinableString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self as &str, f)
     }
 }
@@ -252,7 +246,7 @@ impl Default for InlinableString {
 }
 
 impl fmt::Display for InlinableString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             InlinableString::Heap(ref s) => s.fmt(f),
             InlinableString::Inline(ref s) => s.fmt(f),
@@ -669,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_write() {
-        use fmt::Write;
+        use std::fmt::Write;
         let mut s = InlinableString::new();
         write!(&mut s, "small").expect("!write");
         assert_eq!(s, "small");

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,7 +1,7 @@
+use crate::InlinableString;
 use serde::de::{Deserialize, Deserializer, Error as DeError, Visitor};
 use serde::{Serialize, Serializer};
 use std::fmt;
-use InlinableString;
 
 impl Serialize for InlinableString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -22,7 +22,7 @@ impl<'de> Deserialize<'de> for InlinableString {
         impl<'de> Visitor<'de> for InlinableStringVisitor {
             type Value = InlinableString;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a string")
             }
 
@@ -47,8 +47,8 @@ impl<'de> Deserialize<'de> for InlinableString {
 
 #[cfg(test)]
 mod tests {
+    use crate::InlinableString;
     use serde_test::{assert_tokens, Token};
-    use InlinableString;
 
     #[test]
     fn test_ser_de() {


### PR DESCRIPTION
Applied `cargo fix --edition-idioms`.
Rust compiler can link edition 2015 crates and edition 2018 crates, so this update is non-breaking.