### PR TITLE
Use correct and efficient boundary checks

### DIFF
--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -492,7 +492,7 @@ impl InlineString {
     #[inline]
     pub fn remove(&mut self, idx: usize) -> char {
         self.assert_sanity();
-        assert!(idx <= self.len());
+        assert!(idx < self.len());
 
         match self.char_indices().find(|&(i, _)| i == idx) {
             None => panic!(


### PR DESCRIPTION
* Assertion for the index given for `InlineString::remove()` seems not correct (at least it is inconsistent with `String::remove()`).
    + It should not accept `idx` argument which is equal to `self.len()`.
    + The first commit fixes this.
+ Use efficient boundary check instead of traversing each character in a string.
    + Previous implementation uses `self.char_indices().foo()` for boundary check, but it is `O(n)` operation.
    + `str` type has quite efficient (`O(1)`) implementation.
    + The second commit improve them to use methods of `str` instead of iterators.