### PR TITLE
Implement `insert_str()`

### DIFF
--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -574,6 +574,30 @@ impl InlineString {
         Ok(())
     }
 
+    /// Inserts a string into the string buffer at byte position `idx`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use inlinable_string::InlineString;
+    ///
+    /// let mut s = InlineString::from("foo");
+    /// s.insert_str(2, "bar");
+    /// assert!(s == "fobaro");
+    /// ```
+    #[inline]
+    pub fn insert_str(&mut self, idx: usize, string: &str) -> Result<(), NotEnoughSpaceError> {
+        self.assert_sanity();
+        assert!(idx <= self.len());
+
+        unsafe {
+            self.insert_bytes(idx, string.as_bytes())?;
+        }
+
+        self.assert_sanity();
+        Ok(())
+    }
+
     /// Views the internal string buffer as a mutable sequence of bytes.
     ///
     /// # Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,6 +624,29 @@ impl<'a> StringExt<'a> for InlinableString {
     }
 
     #[inline]
+    fn insert_str(&mut self, idx: usize, string: &str) {
+        let promoted = match *self {
+            InlinableString::Heap(ref mut s) => {
+                s.insert_str(idx, string);
+                return;
+            }
+            InlinableString::Inline(ref mut s) => {
+                if s.insert_str(idx, string).is_ok() {
+                    return;
+                }
+
+                let mut promoted = String::with_capacity(s.len() + string.len());
+                promoted.push_str(&s[..idx]);
+                promoted.push_str(string);
+                promoted.push_str(&s[idx..]);
+                promoted
+            }
+        };
+
+        mem::swap(self, &mut InlinableString::Heap(promoted));
+    }
+
+    #[inline]
     unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
         match *self {
             InlinableString::Heap(ref mut s) => &mut s.as_mut_vec()[..],
@@ -707,6 +730,21 @@ mod tests {
         assert_eq!(
             s,
             String::from_iter((0..INLINE_STRING_CAPACITY + 1).map(|_| 'a'))
+        );
+    }
+
+    #[test]
+    fn test_insert_str() {
+        let mut s = InlinableString::new();
+
+        for _ in 0..(INLINE_STRING_CAPACITY / 3) {
+            s.insert_str(0, "foo");
+        }
+        s.insert_str(0, "foo");
+
+        assert_eq!(
+            s,
+            String::from_iter((0..(INLINE_STRING_CAPACITY / 3) + 1).map(|_| "foo"))
         );
     }
 

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -378,6 +378,29 @@ pub trait StringExt<'a>:
     /// this function will panic.
     fn insert(&mut self, idx: usize, ch: char);
 
+    /// Inserts a string into the string buffer at byte position `idx`.
+    ///
+    /// # Warning
+    ///
+    /// This is an O(n) operation as it requires copying every element in the
+    /// buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use inlinable_string::{InlinableString, StringExt};
+    ///
+    /// let mut s = InlinableString::from("foo");
+    /// s.insert_str(2, "bar");
+    /// assert!(s == "fobaro");
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// If `idx` does not lie on a character boundary or is out of bounds, then
+    /// this function will panic.
+    fn insert_str(&mut self, idx: usize, string: &str);
+
     /// Views the string buffer as a mutable sequence of bytes.
     ///
     /// # Safety
@@ -540,6 +563,11 @@ impl<'a> StringExt<'a> for String {
     #[inline]
     fn insert(&mut self, idx: usize, ch: char) {
         String::insert(self, idx, ch)
+    }
+
+    #[inline]
+    fn insert_str(&mut self, idx: usize, string: &str) {
+        String::insert_str(self, idx, string)
     }
 
     #[inline]


### PR DESCRIPTION
[`String::insert_str`](https://doc.rust-lang.org/stable/std/string/struct.String.html#method.insert_str) is added since Rust 1.16.0, and it would be faster to use `unsafe`.

The last commit adds `StringExt::insert_str()` and it is breaking change.
Withouth the last commit, this patch is non-breaking change.

cc: #26