### PR TITLE
Implement some missing `std::string::String` methods

### DIFF
--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -921,7 +921,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn insert_panic() {
-        let mut s = InlineString::try_from("й").unwrap();
+        let mut s = InlineString::try_from("щ").unwrap();
         let _ = s.insert(1, 'q');
     }
 

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -47,10 +47,10 @@ use std::str;
 ///
 /// Sometime in the future, when Rust's generics support specializing with
 /// compile-time static integers, this number should become configurable.
-#[cfg(target_pointer_width = "64")]
-pub const INLINE_STRING_CAPACITY: usize = 30;
-#[cfg(target_pointer_width = "32")]
-pub const INLINE_STRING_CAPACITY: usize = 14;
+pub const INLINE_STRING_CAPACITY: usize = {
+    use mem::size_of;
+    size_of::<String>() + size_of::<usize>() - 2
+};
 
 /// A short UTF-8 string that uses inline storage and does no heap allocation.
 ///

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -85,15 +85,6 @@ impl AsMut<str> for InlineString {
     }
 }
 
-impl AsMut<[u8]> for InlineString {
-    #[inline]
-    fn as_mut(&mut self) -> &mut [u8] {
-        self.assert_sanity();
-        let length = self.len();
-        &mut self.bytes[0..length]
-    }
-}
-
 /// An error type for `InlineString`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NotEnoughCapacity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,12 @@ impl Borrow<str> for InlinableString {
     }
 }
 
+impl BorrowMut<str> for InlinableString {
+    fn borrow_mut(&mut self) -> &mut str {
+        &mut *self
+    }
+}
+
 impl AsRef<str> for InlinableString {
     fn as_ref(&self) -> &str {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,13 +98,14 @@ pub mod string_ext;
 pub use inline_string::{InlineString, INLINE_STRING_CAPACITY};
 pub use string_ext::StringExt;
 
-use std::borrow::{Borrow, Cow};
+use std::borrow::{Borrow, BorrowMut, Cow};
 use std::cmp::Ordering;
+use std::convert::TryFrom;
 use std::fmt;
 use std::hash;
 use std::iter;
 use std::mem;
-use std::ops;
+use std::ops::{self, RangeBounds};
 use std::string::{FromUtf16Error, FromUtf8Error};
 
 /// An owned, grow-able UTF-8 string that allocates short strings inline on the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,6 +693,17 @@ impl StringExt for InlinableString {
             },
         }
     }
+
+    #[inline]
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(char) -> bool,
+    {
+        match self {
+            Self::Inline(s) => s.retain(f),
+            Self::Heap(s) => s.retain(f),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,15 @@ mod tests {
     use std::cmp::Ordering;
     use std::iter::FromIterator;
 
+    const LONG_STR: &str = "this is a really long string that is much larger than
+                        INLINE_STRING_CAPACITY and so cannot be stored inline.";
+
+    #[test]
+    fn test_long_string() {
+        // If this fails, increase the size of the long string.
+        assert!(LONG_STR.len() > INLINE_STRING_CAPACITY);
+    }
+
     #[test]
     fn test_size() {
         use std::mem::size_of;
@@ -667,10 +676,8 @@ mod tests {
         s.push_str("small");
         assert_eq!(s, "small");
 
-        let long_str = "this is a really long string that is much larger than
-                        INLINE_STRING_CAPACITY and so cannot be stored inline.";
-        s.push_str(long_str);
-        assert_eq!(s, String::from("small") + long_str);
+        s.push_str(LONG_STR);
+        assert_eq!(s, String::from("small") + LONG_STR);
     }
 
     #[test]
@@ -680,10 +687,8 @@ mod tests {
         write!(&mut s, "small").expect("!write");
         assert_eq!(s, "small");
 
-        let long_str = "this is a really long string that is much larger than
-                        INLINE_STRING_CAPACITY and so cannot be stored inline.";
-        write!(&mut s, "{}", long_str).expect("!write");
-        assert_eq!(s, String::from("small") + long_str);
+        write!(&mut s, "{}", LONG_STR).expect("!write");
+        assert_eq!(s, String::from("small") + LONG_STR);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,17 @@ impl StringExt for InlinableString {
     }
 
     #[inline]
+    fn remove_range<R>(&mut self, range: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        match self {
+            InlinableString::Heap(s) => s.remove_range(range),
+            InlinableString::Inline(s) => s.remove_range(range),
+        }
+    }
+
+    #[inline]
     fn insert(&mut self, idx: usize, ch: char) {
         let promoted = match *self {
             InlinableString::Heap(ref mut s) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! // This method can work on strings potentially stored inline on the stack,
 //! // on the heap, or plain old `std::string::String`s!
-//! fn takes_a_string_reference(string: &mut StringExt) {
+//! fn takes_a_string_reference(string: &mut impl StringExt) {
 //!    // Do something with the string...
 //!    string.push_str("it works!");
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,6 +630,29 @@ impl StringExt for InlinableString {
     }
 
     #[inline]
+    fn insert_str(&mut self, idx: usize, string: &str) {
+        let promoted = match *self {
+            InlinableString::Heap(ref mut s) => {
+                s.insert_str(idx, string);
+                return;
+            }
+            InlinableString::Inline(ref mut s) => {
+                if s.insert_str(idx, string).is_ok() {
+                    return;
+                }
+
+                let mut promoted = String::with_capacity(s.len() + string.len());
+                promoted.push_str(&s[..idx]);
+                promoted.push_str(string);
+                promoted.push_str(&s[idx..]);
+                promoted
+            }
+        };
+
+        mem::swap(self, &mut InlinableString::Heap(promoted));
+    }
+
+    #[inline]
     unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
         match *self {
             InlinableString::Heap(ref mut s) => &mut s.as_mut_vec()[..],
@@ -718,6 +741,21 @@ mod tests {
         assert_eq!(
             s,
             String::from_iter((0..INLINE_STRING_CAPACITY + 1).map(|_| 'a'))
+        );
+    }
+
+    #[test]
+    fn test_insert_str() {
+        let mut s = InlinableString::new();
+
+        for _ in 0..(INLINE_STRING_CAPACITY / 3) {
+            s.insert_str(0, "foo");
+        }
+        s.insert_str(0, "foo");
+
+        assert_eq!(
+            s,
+            String::from_iter((0..(INLINE_STRING_CAPACITY / 3) + 1).map(|_| "foo"))
         );
     }
 

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -1050,8 +1050,8 @@ mod provided_methods_tests {
         fn remove(&mut self, idx: usize) -> char {
             self.0.remove(idx)
         }
-        fn insert(&mut self, idx: usize, ch: char) {
-            self.0.insert(idx, ch)
+        fn insert_str(&mut self, idx: usize, string: &str) {
+            self.0.insert_str(idx, string)
         }
         fn len(&self) -> usize {
             self.0.len()

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -57,9 +57,7 @@ where
     ///
     /// let s = InlinableString::with_capacity(10);
     /// ```
-    fn with_capacity(capacity: usize) -> Self
-    where
-        Self: Sized;
+    fn with_capacity(capacity: usize) -> Self;
 
     /// Returns the vector as a string buffer, if possible, taking care not to
     /// copy it.
@@ -534,7 +532,7 @@ fn from_string<S: StringExt>(s: String) -> S {
     unsafe { S::from_utf8_unchecked(<String>::into_bytes(s)) }
 }
 
-impl<'a> StringExt<'a> for String {
+impl StringExt for String {
     #[inline]
     fn new() -> Self {
         String::new()

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -927,6 +927,29 @@ impl StringExt for String {
     }
 }
 
+/// Implementation of some traits from stdlib for `String` type.
+/// This is 1.41.0+ code; before 1.41 orphan rules were too strict.
+mod string_impls {
+    use crate::{InlinableString, InlineString};
+
+    impl From<InlineString> for String {
+        #[inline]
+        fn from(s: InlineString) -> String {
+            String::from(&*s)
+        }
+    }
+
+    impl From<InlinableString> for String {
+        #[inline]
+        fn from(s: InlinableString) -> String {
+            match s {
+                InlinableString::Heap(s) => s,
+                InlinableString::Inline(s) => String::from(s),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod provided_methods_tests {
 

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -623,6 +623,34 @@ where
         self.borrow_mut()
     }
 
+    /// Splits the string into two at the given index.
+    ///
+    /// Returns a new buffer. `self` contains bytes `[0, at)`, and
+    /// the returned buffer contains bytes `[at, len)`. `at` must be on the
+    /// boundary of a UTF-8 code point.
+    ///
+    /// Note that the capacity of `self` does not change.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `at` is not on a `UTF-8` code point boundary, or if it is beyond the last
+    /// code point of the string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() {
+    /// use inlinable_string::{InlinableString, StringExt};
+    ///
+    /// let mut hello = InlinableString::from("Hello, World!");
+    /// let world = hello.split_off(7);
+    /// assert_eq!(hello, "Hello, ");
+    /// assert_eq!(world, "World!");
+    /// # }
+    /// ```
+    #[must_use = "use `.truncate()` if you don't need the other half"]
+    fn split_off(&mut self, at: usize) -> Self;
+
 /// Internal function to decrease the numbers of unsafe.
 #[inline]
 fn from_string<S: StringExt>(s: String) -> S {
@@ -749,6 +777,11 @@ impl StringExt for String {
     fn len(&self) -> usize {
         String::len(self)
     }
+
+    #[inline]
+    fn split_off(&mut self, at: usize) -> Self {
+        <String>::split_off(self, at)
+    }
 }
 
 #[cfg(test)]
@@ -856,6 +889,9 @@ mod provided_methods_tests {
         }
         fn len(&self) -> usize {
             self.0.len()
+        }
+        fn split_off(&mut self, at: usize) -> Self {
+            Self(self.0.split_off(at))
         }
     }
 
@@ -1137,5 +1173,13 @@ mod std_string_stringext_sanity_tests {
         let mut s = String::from("foobar");
         StringExt::remove_range(&mut s, 1..3);
         assert_eq!(s, "fbar");
+    }
+
+    #[test]
+    fn test_split_off() {
+        let mut s = String::from("foobar");
+        let right_part = StringExt::split_off(&mut s, 3);
+        assert_eq!(s, "foo");
+        assert_eq!(right_part, "bar");
     }
 }

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -11,22 +11,25 @@
 //!
 //! See the [crate level documentation](./../index.html) for more.
 
-use std::borrow::{Borrow, Cow};
+use std::borrow::{Borrow, BorrowMut, Cow};
 use std::cmp::PartialEq;
 use std::fmt::Display;
+use std::ops::RangeBounds;
+use std::str;
 use std::string::{FromUtf16Error, FromUtf8Error};
 
 /// A trait that exists to abstract string operations over any number of
 /// concrete string type implementations.
 ///
 /// See the [crate level documentation](./../index.html) for more.
-pub trait StringExt<'a>:
-    Borrow<str>
-    + Display
-    + PartialEq<str>
-    + PartialEq<&'a str>
-    + PartialEq<String>
-    + PartialEq<Cow<'a, str>>
+pub trait StringExt
+where
+    for<'a> Self: Sized
+        + Display
+        + PartialEq<str>
+        + PartialEq<String>
+        + PartialEq<&'a str>
+        + PartialEq<Cow<'a, str>>,
 {
     /// Creates a new string buffer initialized with the empty string.
     ///

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -623,6 +623,33 @@ where
         self.borrow_mut()
     }
 
+    /// Converts this `String` into a [`Box`]`<`[`str`]`>`.
+    ///
+    /// This will drop any excess capacity.
+    ///
+    /// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
+    /// [`str`]: https://doc.rust-lang.org/std/primitive.str.html
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use inlinable_string::{InlinableString, StringExt};
+    ///
+    /// let s = InlinableString::from("hello");
+    ///
+    /// let b = s.into_boxed_str();
+    /// ```
+    #[inline]
+    fn into_boxed_str(self) -> Box<str>
+    where
+        Self: Into<String>,
+    {
+        let s = self.into();
+        <String>::into_boxed_str(s)
+    }
+
     /// Splits the string into two at the given index.
     ///
     /// Returns a new buffer. `self` contains bytes `[0, at)`, and


### PR DESCRIPTION
Closes #26

`INLINE_STRING_CAPACITY`:
![image](https://user-images.githubusercontent.com/43708554/87690404-b63b2d80-c789-11ea-9741-34eb33c1edf0.png)
![image](https://user-images.githubusercontent.com/43708554/87690418-baffe180-c789-11ea-9b61-b6f38ec5bb63.png)

No `drain` method; too much complicated code to write (even more complicated than it normally must be, because we are producing an iterator struct through trait there), while `chars` + `remove_range` pair does exactly the same job. Probably I need to write that in `remove_range` docs.

Minimum Rust version is 1.42 due to `matches!` macro in tests; I dunno if 1.41 would be minimum if user doesn't compile tests (some traits for `String` with 1.41+ orphan rules).

Crate major (middle, cuz it's pre-1.) version must be updated.

`StringExt` can no longer be a trait object.