### PR TITLE
A quick no_std patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "inlinable_string"
 
 description = "The `inlinable_string` crate provides the `InlinableString` type -- an owned, grow-able UTF-8 string that stores small strings inline and avoids heap-allocation -- and the `StringExt` trait which abstracts string operations over both `std::string::String` and `InlinableString` (or even your own custom string type)."
 
-version = "0.1.11"
+version = "0.1.12"
 edition = "2018"
 license = "Apache-2.0/MIT"
 keywords = ["string", "inline", "inlinable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "inlinable_string"
 
 description = "The `inlinable_string` crate provides the `InlinableString` type -- an owned, grow-able UTF-8 string that stores small strings inline and avoids heap-allocation -- and the `StringExt` trait which abstracts string operations over both `std::string::String` and `InlinableString` (or even your own custom string type)."
 
-version = "0.1.12"
+version = "0.1.13"
 edition = "2018"
 license = "Apache-2.0/MIT"
 keywords = ["string", "inline", "inlinable"]
@@ -14,16 +14,17 @@ repository = "https://github.com/fitzgen/inlinable_string"
 
 [dependencies]
 
-[dependencies.clippy]
-optional = true
-version = "0.0.27"
-
 [dependencies.serde]
 optional = true
 version = "1"
 
+[dependencies.bare-io]
+optional = true
+version = "0.2"
+
 [features]
-nightly = ["clippy"]
+nightly = []
+no_std = ["bare-io"]
 
 [dev-dependencies]
 serde_test = "1"

--- a/src/inline_string.rs
+++ b/src/inline_string.rs
@@ -34,13 +34,17 @@
 //! assert_eq!(s, "hi world");
 //! ```
 
-use std::borrow;
-use std::fmt;
-use std::hash;
+use alloc::borrow;
+use core::fmt;
+use core::hash;
+use core::ops;
+use core::ptr;
+use core::str;
+
+#[cfg(feature = "no_std")]
+use bare_io::Write;
+#[cfg(not(feature = "no_std"))]
 use std::io::Write;
-use std::ops;
-use std::ptr;
-use std::str;
 
 /// The capacity (in bytes) of inline storage for small strings.
 /// `InlineString::len()` may never be larger than this.
@@ -680,6 +684,7 @@ impl InlineString {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
     use super::{InlineString, NotEnoughSpaceError, INLINE_STRING_CAPACITY};
 
     #[test]
@@ -718,7 +723,7 @@ mod tests {
 
     #[test]
     fn test_write() {
-        use std::fmt::{Error, Write};
+        use core::fmt::{Error, Write};
 
         let mut s = InlineString::new();
         let mut normal_string = String::new();
@@ -739,5 +744,5 @@ mod benches {
     use test::Bencher;
 
     #[bench]
-    fn its_fast(b: &mut Bencher) {}
+    fn its_fast(_b: &mut Bencher) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,12 @@
 
 #![forbid(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(plugin))]
-#![cfg_attr(feature = "nightly", plugin(clippy))]
-#![cfg_attr(feature = "nightly", deny(clippy))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
+#![cfg_attr(feature = "no_std", no_std)]
+
+#[allow(unused_imports)]
+#[cfg_attr(feature = "no_std", macro_use)]
+extern crate alloc;
 
 #[cfg(test)]
 #[cfg(feature = "nightly")]
@@ -92,14 +95,15 @@ pub mod string_ext;
 pub use inline_string::{InlineString, INLINE_STRING_CAPACITY};
 pub use string_ext::StringExt;
 
-use std::borrow::{Borrow, Cow};
-use std::cmp::Ordering;
-use std::fmt;
-use std::hash;
-use std::iter;
-use std::mem;
-use std::ops;
-use std::string::{FromUtf16Error, FromUtf8Error};
+use alloc::borrow::{Borrow, Cow};
+use alloc::vec::Vec;
+use alloc::string::{FromUtf16Error, FromUtf8Error, String};
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash;
+use core::iter;
+use core::mem;
+use core::ops;
 
 /// An owned, grow-able UTF-8 string that allocates short strings inline on the
 /// stack.
@@ -659,13 +663,14 @@ impl<'a> StringExt<'a> for InlinableString {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::{String, ToString};
+    use core::iter::FromIterator;
     use super::{InlinableString, StringExt, INLINE_STRING_CAPACITY};
-    use std::cmp::Ordering;
-    use std::iter::FromIterator;
+    use core::cmp::Ordering;
 
     #[test]
     fn test_size() {
-        use std::mem::size_of;
+        use core::mem::size_of;
         assert_eq!(size_of::<InlinableString>(), 4 * size_of::<usize>());
     }
 
@@ -686,7 +691,7 @@ mod tests {
 
     #[test]
     fn test_write() {
-        use std::fmt::Write;
+        use core::fmt::Write;
         let mut s = InlinableString::new();
         write!(&mut s, "small").expect("!write");
         assert_eq!(s, "small");
@@ -858,6 +863,8 @@ mod tests {
 #[cfg(test)]
 #[cfg(feature = "nightly")]
 mod benches {
+    #[cfg(feature = "no_std")]
+    use alloc::string::String;
     use super::{InlinableString, StringExt};
     use test::{black_box, Bencher};
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -1,7 +1,8 @@
+use alloc::string::String;
 use crate::InlinableString;
 use serde::de::{Deserialize, Deserializer, Error as DeError, Visitor};
 use serde::{Serialize, Serializer};
-use std::fmt;
+use core::fmt;
 
 impl Serialize for InlinableString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/string_ext.rs
+++ b/src/string_ext.rs
@@ -11,10 +11,11 @@
 //!
 //! See the [crate level documentation](./../index.html) for more.
 
-use std::borrow::{Borrow, Cow};
-use std::cmp::PartialEq;
-use std::fmt::Display;
-use std::string::{FromUtf16Error, FromUtf8Error};
+use alloc::borrow::{Borrow, Cow};
+use alloc::vec::Vec;
+use alloc::string::{String, FromUtf16Error, FromUtf8Error};
+use core::cmp::PartialEq;
+use core::fmt::Display;
 
 /// A trait that exists to abstract string operations over any number of
 /// concrete string type implementations.
@@ -585,6 +586,7 @@ impl<'a> StringExt<'a> for String {
 mod std_string_stringext_sanity_tests {
     // Sanity tests for std::string::String's StringExt implementation.
 
+    use alloc::string::String;
     use super::StringExt;
 
     #[test]


### PR DESCRIPTION
Works in the Linux kernel:

![image](https://user-images.githubusercontent.com/41847/99144336-f6e27f00-2675-11eb-96ea-2683b9b61951.png)

To give it a go, use

    inlinable_string = {git = "https://github.com/ArtemGr/inlinable_string", branch = "no_std", features = ["no_std"]}
